### PR TITLE
php version updated in travis.yml

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,6 +5,9 @@ php:
   - 5.3
   - 5.4
   - 5.5
+  - 5.6
+  - 7.0
+  - hhvm
 
 script:
  - phpunit -c tests/phpunit.xml


### PR DESCRIPTION
The latest php version update into travis.yml and chacked with travis.
it build pass upto php 7.0 and hhvm
